### PR TITLE
Bump to the latest po2json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "PO loader module for webpack",
   "peerDependencies": {
-    "po2json": ">=0.4.5"
+    "po2json": ">=1.0.0-beta-3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think because the latest version of po2json is a beta release, the expression `>=0.4.5` doesn't cause po-loader to get it.

When setting po2json separately to the latest version in our package.json, the following error happens:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: converse.js@9.1.0
npm ERR! Found: po2json@1.0.0-beta-3
npm ERR! node_modules/po2json
npm ERR!   dev po2json@"^1.0.0-beta" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer po2json@">=0.4.5" from po-loader@0.5.0
npm ERR! node_modules/po-loader
npm ERR!   dev po-loader@"^0.5.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Updating po-loaders' package.json to use the latest po2json fixes the issue.

