### PR TITLE
Compatibility fix for loader-utils > 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,11 @@
     Author David Schissler @dschissler
 */
 var po2json = require('po2json');
-var utils = require('loader-utils');
 
 module.exports = function(source) {
     this.cacheable();
 
-    var options = utils.getOptions(this);
+    var options = this.getOptions();
     if (options === null) {
         options = {};
     }


### PR DESCRIPTION
From the release notes:
*removed getOptions in favor loaderContext.getOptions (loaderContext is this inside loader function)*

https://github.com/webpack/loader-utils/releases/tag/v3.0.0

Without this fix, the following error occurs:
```
TypeError: utils.getOptions is not a function
```

